### PR TITLE
ucm-validator: add dummy json to expand tests

### DIFF
--- a/python/ucm-validator/configs/bytcht-cx2072x/dummy.json
+++ b/python/ucm-validator/configs/bytcht-cx2072x/dummy.json
@@ -1,0 +1,19 @@
+{
+    "bytcht-cx2072x-1": {
+        "comment":	"Dummy test configuration for bytcht-cx2072x",
+        "id":		"bytcht-cx2072x",
+        "driver":	"bytcht-cx2072x",
+        "name":		"bytcht-cx2072x",
+        "longname":	"bytcht-cx2072x",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },    
+    "bytcht-cx2072x-2": {
+        "comment":	"Dummy test configuration for bytcht-cx2072x in SOF mode",
+        "id":		"bytcht-cx2072x",
+        "driver":	"bytcht-cx2072x",
+        "name":		"bytcht-cx2072x",
+        "longname":	"bytcht-cx2072x"
+    }
+}

--- a/python/ucm-validator/configs/bytcht-es8316/dummy.json
+++ b/python/ucm-validator/configs/bytcht-es8316/dummy.json
@@ -5,14 +5,20 @@
         "driver":	"bytcht-es8316",
         "name":		"bytcht-es8316",
         "longname":	"bytcht-es8316",
-        "components":	"cfg-spk:1 cfg-mic:in1"
+        "components":	"cfg-spk:1 cfg-mic:in1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcht-es8316-2": {
         "comment":	"Dummy test configuration for bytcht-es8316",
         "id":		"bytcht-es8316",
         "driver":	"bytcht-es8316",
         "name":		"bytcht-es8316",
-        "longname":	"bytcht-es8316-mono-spk-in1-mic"
+        "longname":	"bytcht-es8316-mono-spk-in1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcht-es8316-3": {
         "comment":	"Dummy test configuration for bytcht-es8316",
@@ -20,10 +26,23 @@
         "driver":	"bytcht-es8316",
         "name":		"bytcht-es8316",
         "longname":	"bytcht-es8316",
-        "components":	"cfg-spk:2 cfg-mic:in2"
+        "components":	"cfg-spk:2 cfg-mic:in2",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcht-es8316-4": {
         "comment":	"Dummy test configuration for bytcht-es8316",
+        "id":		"bytcht-es8316",
+        "driver":	"bytcht-es8316",
+        "name":		"bytcht-es8316",
+        "longname":	"bytcht-es8316-stereo-spk-in2-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "bytcht-es8316-5": {
+        "comment":	"Dummy test configuration for bytcht-es8316 in SOF mode",
         "id":		"bytcht-es8316",
         "driver":	"bytcht-es8316",
         "name":		"bytcht-es8316",

--- a/python/ucm-validator/configs/bytcr-rt5640/dummy.json
+++ b/python/ucm-validator/configs/bytcr-rt5640/dummy.json
@@ -5,14 +5,20 @@
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",
         "longname":	"bytcr-rt5640",
-        "components":	"cfg-spk:1 cfg-mic:dmic1"
+        "components":	"cfg-spk:1 cfg-mic:dmic1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5640-2": {
         "comment":	"Dummy test configuration for bytcr-rt5640",
         "id":		"bytcr-rt5640",
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",
-        "longname":	"bytcr-rt5640-mono-spk-dmic1-mic"
+        "longname":	"bytcr-rt5640-mono-spk-dmic1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5640-3": {
         "comment":	"Dummy test configuration for bytcr-rt5640",
@@ -20,14 +26,20 @@
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",
         "longname":	"bytcr-rt5640",
-        "components":	"cfg-spk:2 cfg-mic:dmic1"
+        "components":	"cfg-spk:2 cfg-mic:dmic1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5640-4": {
         "comment":	"Dummy test configuration for bytcr-rt5640",
         "id":		"bytcr-rt5640",
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",
-        "longname":	"bytcr-rt5640-stereo-spk-dmic1-mic"
+        "longname":	"bytcr-rt5640-stereo-spk-dmic1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5640-5": {
         "comment":	"Dummy test configuration for bytcr-rt5640",
@@ -35,10 +47,23 @@
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",
         "longname":	"bytcr-rt5640",
-        "components":	"cfg-spk:2 cfg-mic:in1"
+        "components":	"cfg-spk:2 cfg-mic:in1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5640-6": {
         "comment":	"Dummy test configuration for bytcr-rt5640",
+        "id":		"bytcr-rt5640",
+        "driver":	"bytcr-rt5640",
+        "name":		"bytcr-rt5640",
+        "longname":	"bytcr-rt5640-stereo-spk-in1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "bytcr-rt5640-7": {
+        "comment":	"Dummy test configuration for bytcr-rt5640 in SOF mode",
         "id":		"bytcr-rt5640",
         "driver":	"bytcr-rt5640",
         "name":		"bytcr-rt5640",

--- a/python/ucm-validator/configs/bytcr-rt5651/dummy.json
+++ b/python/ucm-validator/configs/bytcr-rt5651/dummy.json
@@ -5,14 +5,20 @@
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
         "longname":	"bytcr-rt5651",
-        "components":	"cfg-spk:1 cfg-hp:lrswap cfg-mic:dmic1"
+        "components":	"cfg-spk:1 cfg-hp:lrswap cfg-mic:dmic1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-2": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
         "id":		"bytcr-rt5651",
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
-        "longname":	"bytcr-rt5651-mono-spk-mic-hp-swapped-dmic1-mic"
+        "longname":	"bytcr-rt5651-mono-spk-mic-hp-swapped-dmic1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-3": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
@@ -20,14 +26,20 @@
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
         "longname":	"bytcr-rt5651",
-        "components":	"cfg-spk:2 cfg-mic:in1"
+        "components":	"cfg-spk:2 cfg-mic:in1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-4": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
         "id":		"bytcr-rt5651",
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
-        "longname":	"bytcr-rt5651-stereo-spk-in1-mic"
+        "longname":	"bytcr-rt5651-stereo-spk-in1-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-5": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
@@ -35,14 +47,20 @@
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
         "longname":	"bytcr-rt5651",
-        "components":	"cfg-spk:2 cfg-mic:in2"
+        "components":	"cfg-spk:2 cfg-mic:in2",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-6": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
         "id":		"bytcr-rt5651",
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
-        "longname":	"bytcr-rt5651-stereo-spk-in2-mic"
+        "longname":	"bytcr-rt5651-stereo-spk-in2-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-7": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
@@ -50,13 +68,27 @@
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
         "longname":	"bytcr-rt5651",
-        "components":	"cfg-spk:2 cfg-mic:in12"
+        "components":	"cfg-spk:2 cfg-mic:in12",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "bytcr-rt5651-8": {
         "comment":	"Dummy test configuration for bytcr-rt5651",
         "id":		"bytcr-rt5651",
         "driver":	"bytcr-rt5651",
         "name":		"bytcr-rt5651",
+        "longname":	"bytcr-rt5651-stereo-spk-in12-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "bytcr-rt5651-9": {
+        "comment":	"Dummy test configuration for bytcr-rt5651 in SOF mode",
+        "id":		"bytcr-rt5651",
+        "driver":	"bytcr-rt5651",
+        "name":		"bytcr-rt5651",
         "longname":	"bytcr-rt5651-stereo-spk-in12-mic"
     }
+
 }

--- a/python/ucm-validator/configs/cht-bsw-rt5672/cht-bsw-rt5672.json
+++ b/python/ucm-validator/configs/cht-bsw-rt5672/cht-bsw-rt5672.json
@@ -1,19 +1,19 @@
 {
-    "cht-bsw-rt5672-stereo-dmic2": {
+    "cht-bsw-rt5672-1": {
         "comment":	"Dummy test configuration for cht-bsw-rt5672-stereo-dmic2",
         "id":		"chtbsw",
         "driver":	"cht-bsw-rt5672",
-        "name":		"cht-bsw-rt5672-stereo-dmic2",
-        "longname":	"cht-bsw-rt5672-stereo-dmic2",
+        "name":		"cht-bsw-rt5672",
+        "longname":	"cht-bsw-rt5672",
 	"control": [
             { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
         ]
     },
-    "cht-bsw-rt5672-stereo-dmic2-SOF": {
+    "cht-bsw-rt5672-2": {
         "comment":	"Dummy test configuration for cht-bsw-rt5672-stereo-dmic2 in SOF mode",
         "id":		"chtbsw",
         "driver":	"cht-bsw-rt5672",
-        "name":		"cht-bsw-rt5672-stereo-dmic2",
-        "longname":	"cht-bsw-rt5672-stereo-dmic2"
+        "name":		"cht-bsw-rt5672",
+        "longname":	"cht-bsw-rt5672"
     }
 }

--- a/python/ucm-validator/configs/chtnau8824/dummy.json
+++ b/python/ucm-validator/configs/chtnau8824/dummy.json
@@ -4,6 +4,33 @@
         "id":		"chtnau8824",
         "driver":	"chtnau8824",
         "name":		"chtnau8824",
+        "longname":	"chtnau8824-mono",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "chtnau8824-2": {
+        "comment":	"Dummy test configuration for chtnau8824",
+        "id":		"chtnau8824",
+        "driver":	"chtnau8824",
+        "name":		"chtnau8824",
+        "longname":	"chtnau8824",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "chtnau8824-3": {
+        "comment":	"Dummy test configuration for chtnau8824 in SOF mode",
+        "id":		"chtnau8824",
+        "driver":	"chtnau8824",
+        "name":		"chtnau8824",
         "longname":	"chtnau8824-mono"
+    },
+    "chtnau8824-4": {
+        "comment":	"Dummy test configuration for chtnau8824 in SOF mode",
+        "id":		"chtnau8824",
+        "driver":	"chtnau8824",
+        "name":		"chtnau8824",
+        "longname":	"chtnau8824"
     }
 }

--- a/python/ucm-validator/configs/chtrt5645/dummy.json
+++ b/python/ucm-validator/configs/chtrt5645/dummy.json
@@ -4,24 +4,64 @@
         "id":		"chtrt5645",
         "driver":	"chtrt5645",
         "name":		"chtrt5645",
-        "longname":	"chtrt5645"
+        "longname":	"chtrt5645",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "chtrt5645-2": {
         "comment":	"Dummy test configuration for chtrt5645",
         "id":		"chtrt5645",
         "driver":	"chtrt5645",
         "name":		"chtrt5645",
-        "longname":	"chtrt5645-dmic1"
+        "longname":	"chtrt5645-dmic1",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "chtrt5645-3": {
         "comment":	"Dummy test configuration for chtrt5645",
         "id":		"chtrt5645",
         "driver":	"chtrt5645",
         "name":		"chtrt5645",
-        "longname":	"chtrt5645-dmic2"
+        "longname":	"chtrt5645-dmic2",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
     },
     "chtrt5645-4": {
         "comment":	"Dummy test configuration for chtrt5645",
+        "id":		"chtrt5645",
+        "driver":	"chtrt5645",
+        "name":		"chtrt5645",
+        "longname":	"chtrt5645-mono-speaker-analog-mic",
+	"control": [
+            { "id": "iface=CARD,name='media0_in Gain 0 Switch'" }
+        ]
+    },
+    "chtrt5645-5": {
+        "comment":	"Dummy test configuration for chtrt5645 in SOF mode",
+        "id":		"chtrt5645",
+        "driver":	"chtrt5645",
+        "name":		"chtrt5645",
+        "longname":	"chtrt5645"
+    },
+    "chtrt5645-6": {
+        "comment":	"Dummy test configuration for chtrt5645 in SOF mode",
+        "id":		"chtrt5645",
+        "driver":	"chtrt5645",
+        "name":		"chtrt5645",
+        "longname":	"chtrt5645-dmic1"
+    },
+    "chtrt5645-7": {
+        "comment":	"Dummy test configuration for chtrt5645 in SOF mode",
+        "id":		"chtrt5645",
+        "driver":	"chtrt5645",
+        "name":		"chtrt5645",
+        "longname":	"chtrt5645-dmic2"
+    },
+    "chtrt5645-8": {
+        "comment":	"Dummy test configuration for chtrt5645 in SOF mode",
         "id":		"chtrt5645",
         "driver":	"chtrt5645",
         "name":		"chtrt5645",


### PR DESCRIPTION
Add new configs with the Baytrail/Cherrytrail legacy test

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>