### PR TITLE
ucm-validator: specify topdir explicitly

### DIFF
--- a/python/ucm-validator/ucm.py
+++ b/python/ucm-validator/ucm.py
@@ -83,13 +83,14 @@ def env(filename, lvl=0):
 
 def do_one(*args):
     env(args[0], 2)
-    c = Ucm2()
+    # Optional second arg with top dir
+    c = Ucm2(args[1] if len(args) > 1 else args[0] + '/../..')
     c.load(args[0])
 
 def do_all(*args):
 
-    def pp(filename):
-        c = Ucm2()
+    def pp(filename, topdir):
+        c = Ucm2(topdir)
         c.load(filename)
 
     if len(args) == 0:
@@ -98,7 +99,7 @@ def do_all(*args):
     env(args[0])
     cs = ucm_get_configs(args[0])
     for c in cs:
-        pp(c)
+        pp(c, args[0])
 
 def do_configs(*args):
 
@@ -117,7 +118,7 @@ def do_configs(*args):
             else:
                 configs[k].update(config[k])
 
-    def config_walk(path1):
+    def config_walk(path1, topdir):
         errors = 0
         warnings = 0
         for file in os.listdir(path1):
@@ -125,7 +126,7 @@ def do_configs(*args):
                 continue
             path2 = path1 + '/' + file
             if os.path.isdir(path2):
-                errors1, warnings1 = config_walk(path2)
+                errors1, warnings1 = config_walk(path2, topdir)
                 errors += errors1
                 warnings += warnings1
                 continue
@@ -143,7 +144,7 @@ def do_configs(*args):
                 card = info.cards[cardnum]
                 if card.driver in SKIP_DRIVERS:
                     continue
-                c = Ucm2(verify=card)
+                c = Ucm2(topdir, verify=card)
                 for l in c.get_file_list(ucm_path):
                     if os.path.exists(l):
                         break
@@ -181,7 +182,7 @@ def do_configs(*args):
     filter = args[2:]
     conditions = {}
     configs = {'suppress_if': {}}
-    errors, warnings = config_walk(alsainfo_path)
+    errors, warnings = config_walk(alsainfo_path, ucm_path)
     # check, if all configuration files were handled
     cs = ucm_get_configs(args[0], short=True, link=False)
     for c in cs:

--- a/python/ucm-validator/ucmlib.py
+++ b/python/ucm-validator/ucmlib.py
@@ -504,7 +504,7 @@ class UcmVerb:
         if filename[0] != '/':
             filename = self.ucm.cfgdir() + '/' + filename
         else:
-            filename = self.ucm.topdir() + '/' + filename[1:]
+            filename = self.ucm.topdir + '/' + filename[1:]
         self.ucm.indent_check(filename)
         aconfig = AlsaConfigUcm()
         self.log(1, "Verb '%s', file '%s'", verbname, self.ucm.shortfn(filename))
@@ -621,8 +621,9 @@ class UcmVerb:
 
 class Ucm:
 
-    def __init__(self, verify=None):
+    def __init__(self, topdir, verify=None):
         """Ucm configuration class."""
+        self.topdir = os.path.abspath(topdir)
         self.verify = verify
         self.var = {}
 
@@ -659,16 +660,12 @@ class Ucm:
     def cfgdir(self):
         return os.path.split(self.filename)[0]
 
-    def topdir(self):
-        return os.path.split(self.cfgdir())[0]
-
     def shortfn(self, filename=None):
         if filename is None:
             filename = self.filename
-        topdir = self.topdir()
-        if not filename.startswith(topdir):
-            raise UcmError("shortfn mismatch '%s' / '%s'" % (topdir, filename))
-        return filename[len(topdir)+1:]
+        if not filename.startswith(self.topdir):
+            raise UcmError("shortfn mismatch '%s' / '%s'" % (self.topdir, filename))
+        return filename[len(self.topdir)+1:]
 
     def get_id(self, node):
         if not self.verify and node.id.find('#') >= 0:
@@ -767,7 +764,7 @@ class Ucm:
             if id == '${ConfTopDir}':
                 if self.syntax < 3:
                     self.error(node, "cannot substitute ${ConfTopDir} (requires 'Syntax 3')")
-                s = s.replace(m, self.topdir())
+                s = s.replace(m, self.topdir)
             elif id == '${ConfDir}':
                 if self.syntax < 3:
                     self.error(node, "cannot substitute ${ConfDir} (requires 'Syntax 3')")
@@ -1054,7 +1051,7 @@ class Ucm:
             if filename[0] != '/':
                 filename = self.cfgdir() + '/' + filename
             else:
-                filename = self.topdir() + '/' + filename[1:]
+                filename = self.topdir + '/' + filename[1:]
             if not self.verify and self.invalid_filename(filename):
                 continue
             nodes = AlsaConfigUcm()


### PR DESCRIPTION
With the recent alsa-ucm-conf changes there Ucm.topdir() fails to return
correct values resulting in cryptic messages like the following one:
"No such file or directory: '/__w/alsa-ucm-conf/alsa-ucm-conf/alsa-ucm-conf/ucm2/conf.d/Qualcomm/apq8016-sbc/HiFi.conf'"

Specify topdir explicitly.

Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>