### PR TITLE
ucm-validator: update DB845c card name

### DIFF
--- a/python/ucm-validator/configs/Qualcomm/DB845c.txt
+++ b/python/ucm-validator/configs/Qualcomm/DB845c.txt
@@ -62,7 +62,7 @@ Pulseaudio:
 !!Soundcards recognised by ALSA
 !!-----------------------------
 
- 0 [DB845c         ]: DB845c - DB845c
+ 0 [DB845c         ]: sdm845 - DB845c
                       DB845c
 
 


### PR DESCRIPTION
Since 5.10 DB845c has changed sound card name, so update alsa-info dump
accordingly.

Link: https://lore.kernel.org/r/20201023095849.22894-1-srinivas.kandagatla@linaro.org
Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>