### PR TITLE
ucm-validator/Qualcomm: correct DB820c driver name

### DIFF
--- a/python/ucm-validator/configs/Qualcomm/DB820c.json
+++ b/python/ucm-validator/configs/Qualcomm/DB820c.json
@@ -3,7 +3,7 @@
         "comment":	"Dummy test configuration for DB820c",
         "id":		"DB820c",
         "module":	"snd_soc_apq8096",
-        "driver":	"DB820c",
+        "driver":	"apq8096",
         "name":		"DB820c",
         "longname":	"DB820c"
     }


### PR DESCRIPTION
Since release 6.3 Linux kernel uses apq8096 as a driver name. Follow this change in the ucm-validator configuration.