### PR TITLE
Fix SyntaxWarning for regex in substitute2

### DIFF
--- a/python/ucm-validator/ucmlib.py
+++ b/python/ucm-validator/ucmlib.py
@@ -770,7 +770,7 @@ class Ucm:
             return s
         if self.syntax < 2:
             self.error(node, "cannot substitute (requires 'Syntax 2')")
-        r1 = "\$[\$]{0,1}{[\$.,:;@_a-zA-Z0-9-]+}"
+        r1 = r"\$\$?{[$.,:;@_a-zA-Z0-9-]+}"
         for m in re.findall(r1, s):
             if m[0:2] == '$$':
                 id = m[1:]


### PR DESCRIPTION
Fixes the warning that can be seen here: https://github.com/alsa-project/alsa-ucm-conf/actions/runs/11346809053/job/31556723007#step:6:7

- Use a raw string for the regex like in all other cases
- Remove unnecessary escape for dollar in character class
- Simplify matching for optional dollar at second character